### PR TITLE
Replaced function packlen with packsize in knx-gateway-info script

### DIFF
--- a/scripts/knx-gateway-info.nse
+++ b/scripts/knx-gateway-info.nse
@@ -56,7 +56,7 @@ local knxParseDescriptionResponse = function(knxMessage)
   end
 
   local message_format = '>BBB c1 I2 c2 c6 c4 c6 c30 BB'
-  if #knxMessage - pos + 1 < string.packlen(message_format) then
+  if #knxMessage - pos + 1 < string.packsize(message_format) then
     stdnse.debug1("Message too short for KNX message")
     return
   end


### PR DESCRIPTION
The function string.packlen does not exist (same issue https://github.com/nmap/nmap/pull/2727). 

Used nmap version: 
```
Nmap version 7.94 ( https://nmap.org )
Platform: x86_64-pc-linux-gnu
Compiled with: liblua-5.4.6 openssl-3.1.2 libssh2-1.11.0 libz-1.3 libpcre-8.45 libpcap-1.10.4 nmap-libdnet-1.12 ipv6
Compiled without:
Available nsock engines: epoll poll select
```

The fix was tested against a KNX setup:
```
Nmap scan report for 172.19.0.
Host is up, received arp-response (0.00018s latency).
Scanned at 2023-10-23 07:27:03 CEST for 0s

PORT     STATE         SERVICE REASON
3671/udp open|filtered efcp    no-response
| knx-gateway-info: 
|   Header: 
|     Header length: 6
|     Protocol version: 16
|     Service type: DESCRIPTION_RESPONSE (0x0204)
|     Total length: 82
|   Body: 
|     DIB_DEV_INFO: 
|       Description type: Device Information
|       KNX medium: KNX TP1
|       Device status: 00
|       KNX address: 15.15.15
|       Project installation identifier: 0000
|       Decive serial: 00010052178f
|       Multicast address: 0.0.0.0
|       Device MAC address: 00:0e:8c:00:b9:d7
|       Device friendly name: IP-Schnittstelle Secure 
|     DIB_SUPP_SVC_FAMILIES: 
|       KNXnet/IP Core version 2
|       KNXnet/IP Device Management version 2
|       KNXnet/IP Tunnelling version 2
|       KNXnet/IP Remote Configuration and Diagnosis version 1
|       12 version 254
|       0 version 1
|       KNXnet/IP Object Server version 0
|       0 version 14
|       140 version 0
|_      185 version 199
MAC Address: 00:0E:8C:00:B9:C7 (Siemens AG)
Final times for host: srtt: 179 rttvar: 5000  to: 100000
```